### PR TITLE
Upgrade TypeScript to version 5.8.3.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,9 @@
         "react-scripts": "5.0.1",
         "react-webcam": "^7.2.0",
         "recharts": "^2.15.1"
+      },
+      "devDependencies": {
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -17828,17 +17831,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
   },
   "overrides": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "typescript": "^4.9.5"
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
Updated TypeScript from 4.9.5 to 5.8.3, moving it to devDependencies. Adjusted related dependencies and node engine requirements in package configuration files.